### PR TITLE
Fix for issue #2 and exec refactor

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,4 +3,8 @@ class dockutil{
         source => 'kcrawford/dockutil',
         path   => "${boxen::config::cachedir}/dockutil",
     }
+    exec {"dockutil kill dock":
+      command =>  "killall cfprefsd;sleep 3;killall Dock",
+      refreshonly => true,
+    }
 }

--- a/manifests/item.pp
+++ b/manifests/item.pp
@@ -1,7 +1,7 @@
 define dockutil::item (
-	$item, 
-	$label, 
-	$action = "add", 
+	$item,
+	$label,
+	$action = "add",
 	$position = "unset",
 	)
 {
@@ -19,30 +19,20 @@ case $action {
 				},
 			onlyif => "${boxen::config::cachedir}/dockutil/scripts/dockutil --find \"${label}\" | grep -qx \"${label} was not found in /Users/${::luser}/Library/Preferences/com.apple.dock.plist\"",
 			require => Repository['Dockutil'],
-			notify => Exec["kill dock ${label}"],
+			notify => Exec['dockutil kill dock'],
 		}
 	}
-	
+
 	"remove":{
 		exec {"dockutil-$label-$item":
 			require => Repository['Dockutil'],
 			command => "${boxen::config::cachedir}/dockutil/scripts/dockutil --remove \"${label}\" --no-restart",
 			onlyif => "${boxen::config::cachedir}/dockutil/scripts/dockutil --find \"${label}\" | grep -q \"${label} was found\"",
-			notify => Exec["kill dock ${label}"],
+			notify => Exec['dockutil kill dock'],
 		}
 	}
 
 }
 
-exec {"kill dock $label": 
-	command =>  "killall Dock; sleep 3",
-	notify => Exec["sleep ${label}"],
-	refreshonly => true,
-	}
-	
-exec {"sleep $label": 
-	command => "sleep 1",
-	refreshonly => true,
-}
 
 }


### PR DESCRIPTION
Fix for https://github.com/grahamgilbert/puppet-dockutil/issues/2

Also included an improvement for the actual Dock restart. Now, it will restart the Dock only once, instead of once per change.
