### PR TITLE
Variable dockutil version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class dockutil (
   }
 
   repository { 'Dockutil':
-    ensure => $version,
+    ensure => $rel,
     source => 'kcrawford/dockutil',
     path   => "${boxen::config::cachedir}/dockutil",
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,8 +2,10 @@ class dockutil (
   $version = undef
 ) {
 
-  unless $version {
-    $version = '4bbdbc95519b70ac00391c4ebe34592fd351f491'
+  if $version {
+    $rel = $version
+  } else {
+    $rel = '4bbdbc95519b70ac00391c4ebe34592fd351f491'
   }
 
   repository { 'Dockutil':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,13 @@
-class dockutil{
+class dockutil (
+  $version = undef
+) {
+
+  unless $version {
+    $version = '4bbdbc95519b70ac00391c4ebe34592fd351f491'
+  }
+
   repository { 'Dockutil':
-    ensure => '4bbdbc95519b70ac00391c4ebe34592fd351f491',
+    ensure => $version,
     source => 'kcrawford/dockutil',
     path   => "${boxen::config::cachedir}/dockutil",
   }


### PR DESCRIPTION
I had a need to get the newest commit of dockutil since I have Yosemite, so I have added the ability to request a specific version of dockutil in the module.  I tested it using hiera in `boxen` and it seems to work quite well:

``` yaml
dockutil::version: 2.0.2
```
